### PR TITLE
Cause Specific algorithm changes (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed computation of RUCA/URIC variables in RuralUrbanUtils; renamed some methods.
 - Added support to IARC Multiple Primary Algorithm.
+- Changed Cause Specific algorithm to support missing or unknown cause of death values.
 
 **Changes in version 1.16**
 

--- a/src/main/java/com/imsweb/algorithms/causespecific/CauseSpecificInputDto.java
+++ b/src/main/java/com/imsweb/algorithms/causespecific/CauseSpecificInputDto.java
@@ -17,8 +17,6 @@ public class CauseSpecificInputDto {
 
     private String _dateOfLastContactYear;
 
-    private String _vitalStatus;
-
     public CauseSpecificInputDto() {
     }
 
@@ -68,13 +66,5 @@ public class CauseSpecificInputDto {
 
     public void setDateOfLastContactYear(String dateOfLastContactYear) {
         _dateOfLastContactYear = dateOfLastContactYear;
-    }
-
-    public String getVitalStatus() {
-        return _vitalStatus;
-    }
-
-    public void setVitalStatus(String vitalStatus) {
-        _vitalStatus = vitalStatus;
     }
 }

--- a/src/main/java/com/imsweb/algorithms/causespecific/CauseSpecificUtils.java
+++ b/src/main/java/com/imsweb/algorithms/causespecific/CauseSpecificUtils.java
@@ -31,11 +31,11 @@ public final class CauseSpecificUtils {
     public static final String PROP_DOLC_YEAR = "dateOfLastContactYear";
     public static final String PROP_COD = "causeOfDeath";
     public static final String PROP_ICD_REVISION_NUM = "icdRevisionNumber";
-    public static final String PROP_VITAL_STATUS = "vitalStatus";
 
     //values for cause specific and cause others
     public static final String ALIVE_OR_DEAD_OF_OTHER_CAUSES = "0";
     public static final String DEAD = "1";
+    public static final String MISSING_UNKNOWN_DEATH_OF_CODE = "8";
     public static final String NA_NOT_FIRST_TUMOR = "9";
     //lookup for tables
     private static List<CauseSpecificDataDto> _DATA_SITE_SPECIFIC = new ArrayList<>();
@@ -51,7 +51,6 @@ public final class CauseSpecificUtils {
      * <li>primarySite (#400)</li>
      * <li>behaviorIcdO3 (#523)</li>
      * <li>dateOfLastContactYear (#1750)</li>
-     * <li>vitalStatus (#1760)</li>
      * </ul>
      * All those properties are defined as constants in this class.
      * <br/><br/>
@@ -78,7 +77,6 @@ public final class CauseSpecificUtils {
      * <li>_primarySite</li>
      * <li>_behaviorIcdO3</li>
      * <li>_dateOfLastContactYear</li>
-     * <li>_vitalStatus</li>
      * </ul>
      * <br/><br/>
      * @param input an input dto which has the fields used to compute cause specific values as parameter.
@@ -105,7 +103,6 @@ public final class CauseSpecificUtils {
      * <li>primarySite (#400)</li>
      * <li>behaviorIcdO3 (#523)</li>
      * <li>dateOfLastContactYear (#1750)</li>
-     * <li>vitalStatus (#1760)</li>
      * </ul>
      * All those properties are defined as constants in this class.
      * <br/><br/>
@@ -126,7 +123,6 @@ public final class CauseSpecificUtils {
         input.setDateOfLastContactYear(record.get(PROP_DOLC_YEAR));
         input.setCauseOfDeath(record.get(PROP_COD));
         input.setIcdRevisionNumber(record.get(PROP_ICD_REVISION_NUM));
-        input.setVitalStatus(record.get(PROP_VITAL_STATUS));
         return computeCauseSpecific(input, cutOffYear);
     }
 
@@ -141,7 +137,6 @@ public final class CauseSpecificUtils {
      * <li>_primarySite</li>
      * <li>_behaviorIcdO3</li>
      * <li>_dateOfLastContactYear</li>
-     * <li>_vitalStatus</li>
      * </ul>
      * <br/><br/>
      * @param input an input dto which has the fields used to compute cause specific values as parameter.
@@ -175,13 +170,9 @@ public final class CauseSpecificUtils {
             return result;
         }
 
-        if (input.getCauseOfDeath() == null || input.getCauseOfDeath().length() < 3) {
-            result.setCauseSpecificDeathClassification(ALIVE_OR_DEAD_OF_OTHER_CAUSES);
-            //if dead
-            if (("4".equals(input.getVitalStatus())) || ("0".equals(input.getVitalStatus())))
-                result.setCauseOtherDeathClassification(DEAD);
-            else
-                result.setCauseOtherDeathClassification(ALIVE_OR_DEAD_OF_OTHER_CAUSES);
+        if (input.getCauseOfDeath() == null || input.getCauseOfDeath().length() < 3 || "7777".equals(input.getCauseOfDeath()) || "7797".equals(input.getCauseOfDeath())) {
+            result.setCauseSpecificDeathClassification(MISSING_UNKNOWN_DEATH_OF_CODE);
+            result.setCauseOtherDeathClassification(MISSING_UNKNOWN_DEATH_OF_CODE);
             return result;
         }
 

--- a/src/test/java/com/imsweb/algorithms/causespecific/CauseSpecificUtilsTest.java
+++ b/src/test/java/com/imsweb/algorithms/causespecific/CauseSpecificUtilsTest.java
@@ -36,8 +36,6 @@ public class CauseSpecificUtilsTest {
         Assert.assertEquals(CauseSpecificUtils.PROP_COD, field.getName());
         field = layout.getFieldByName(CauseSpecificUtils.PROP_ICD_REVISION_NUM);
         Assert.assertEquals(CauseSpecificUtils.PROP_ICD_REVISION_NUM, field.getName());
-        field = layout.getFieldByName(CauseSpecificUtils.PROP_VITAL_STATUS);
-        Assert.assertEquals(CauseSpecificUtils.PROP_VITAL_STATUS, field.getName());
     }
 
     @Test
@@ -63,19 +61,6 @@ public class CauseSpecificUtilsTest {
         Assert.assertEquals("0", CauseSpecificUtils.computeCauseSpecific(input, 2012).getCauseSpecificDeathClassification());
         Assert.assertEquals("0", CauseSpecificUtils.computeCauseSpecific(input, 2012).getCauseOtherDeathClassification());
 
-        // Test Vital Status of 0 or 4 results in Death.
-        record.put(CauseSpecificUtils.PROP_SEQ_NUM_CENTRAL, "00");
-        record.put(CauseSpecificUtils.PROP_ICD_REVISION_NUM, "1");
-        record.put(CauseSpecificUtils.PROP_DOLC_YEAR, "2013");
-        record.put(CauseSpecificUtils.PROP_COD, "99");
-        record.put(CauseSpecificUtils.PROP_VITAL_STATUS, "0");
-        Assert.assertEquals("1", CauseSpecificUtils.computeCauseSpecific(record).getCauseOtherDeathClassification());
-        record.put(CauseSpecificUtils.PROP_VITAL_STATUS, "4");
-        Assert.assertEquals("1", CauseSpecificUtils.computeCauseSpecific(record).getCauseOtherDeathClassification());
-        record.put(CauseSpecificUtils.PROP_VITAL_STATUS, "2");
-        Assert.assertEquals("0", CauseSpecificUtils.computeCauseSpecific(record).getCauseOtherDeathClassification());
-
-
         //All other cases are covered in the testCsvFile() method.
     }
 
@@ -91,7 +76,6 @@ public class CauseSpecificUtilsTest {
             rec.put(CauseSpecificUtils.PROP_PRIMARY_SITE, row[3]);
             rec.put(CauseSpecificUtils.PROP_HISTOLOGY_ICDO3, row[4]);
             rec.put(CauseSpecificUtils.PROP_DOLC_YEAR, row[5]);
-            rec.put(CauseSpecificUtils.PROP_VITAL_STATUS, row[6]);
             String causeSpecificExpected = row[7];
             String causeOtherExpected = row[8];
             String causeSpecificCalculated = CauseSpecificUtils.computeCauseSpecific(rec).getCauseSpecificDeathClassification();

--- a/src/test/resources/causespecific/testCauseSpecific.csv
+++ b/src/test/resources/causespecific/testCauseSpecific.csv
@@ -8,10 +8,12 @@ AA,1,C798,C400,8000,2012,,9,9,invalid sequence number
 00,,C798,C400,8000,2012,,0,1,null icd revision
 00,0,C798,C400,8000,2012,,0,0,patient is alive
 00,0,,,,,,0,0,patient is alive
-00,1,,C809,8100,2012,4,0,1,cod blank patient dead
-00,1,,C809,8100,2012,0,0,1,cod blank patient dead
-00,1,,C809,8100,2012,1,0,0,cod blank patient alive
-00,1,,C809,8100,2012,,0,0,cod blank 
+00,1,,C809,8100,2012,4,8,8,cod blank patient dead
+00,1,,C809,8100,2012,0,8,8,cod blank patient dead
+00,1,,C809,8100,2012,1,8,8,cod blank patient alive
+00,1,,C809,8100,2012,,8,8,cod blank
+00,8,7777,,,,,8,8,unknown cod
+00,8,7797,,,,,8,8,unknown cod
 00,8,140 ,,,,,1,0,icd-8 sequence 00 any cancer (140-239)
 00,8,1407,C809,8000,2012,,1,0,icd-8 sequence 00 any cancer (140-239)
 00,8,161 ,,8000,2012,,1,0,icd-8 sequence 00 any cancer (140-239)


### PR DESCRIPTION
- Set a value of 8 (unknown/missing COD – 7777 or 7797) for the fields SEER Cause-specific death classification and SEER Other cause of death classification.

closes #39 